### PR TITLE
Ensure exact front to back sorting order for terraint tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'earth.worldwind:worldwind:1.1.8'
+    implementation 'earth.worldwind:worldwind:1.1.9'
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 
 allprojects {
     group = "earth.worldwind"
-    version = "1.1.8"
+    version = "1.1.9"
 
     extra.apply {
         set("minSdk", 26) // java.time requires Oreo. Use "isCoreLibraryDesugaringEnabled = true" to lower API to KitKat

--- a/worldwind/src/androidMain/kotlin/earth/worldwind/layer/TiledImageLayer.kt
+++ b/worldwind/src/androidMain/kotlin/earth/worldwind/layer/TiledImageLayer.kt
@@ -31,7 +31,7 @@ actual abstract class TiledImageLayer actual constructor(name: String): Abstract
         } else {
             format == CompressFormat.WEBP
         }
-        val content = getOrSetupTilesContent(pathName, tableName, readOnly, isWebp)
+        val content = getOrSetupTilesContent(pathName, tableName, readOnly, isWebp).also { cacheContent = it }
         tiledSurfaceImage?.cacheTileFactory = GpkgTileFactory(content).also {
             it.format = format
             it.quality = quality

--- a/worldwind/src/androidMain/kotlin/earth/worldwind/ogc/gpkg/GeoPackage.kt
+++ b/worldwind/src/androidMain/kotlin/earth/worldwind/ogc/gpkg/GeoPackage.kt
@@ -75,7 +75,7 @@ actual open class GeoPackage actual constructor(pathName: String, isReadOnly: Bo
                     extension_name TEXT NOT NULL,
                     definition TEXT NOT NULL,
                     scope TEXT NOT NULL,
-                    CONSTRAINT ge_tce UNIQUE (table_name, column_name, extension_name)
+                    UNIQUE (table_name, column_name, extension_name)
                 )
             """.trimIndent())
         }
@@ -418,4 +418,46 @@ actual open class GeoPackage actual constructor(pathName: String, isReadOnly: Bo
                 ) else null
             } }
         }
+
+    override suspend fun deleteContent(content: GpkgContent) {
+        connection.openDatabase().use { database ->
+            database.delete("gpkg_contents", "table_name=?", arrayOf(content.tableName))
+        }
+    }
+
+    override suspend fun deleteMatrixSet(matrixSet: GpkgTileMatrixSet) {
+        connection.openDatabase().use { database ->
+            database.delete("gpkg_tile_matrix_set", "table_name=?", arrayOf(matrixSet.tableName))
+        }
+    }
+
+    override suspend fun deleteMatrix(matrix: GpkgTileMatrix) {
+        connection.openDatabase().use { database ->
+            val args = arrayOf(matrix.tableName, matrix.zoomLevel.toString())
+            database.delete("gpkg_tile_matrix", "table_name=? AND zoom_level=?", args)
+        }
+    }
+
+    override suspend fun deleteExtension(extension: GpkgExtension) {
+        connection.openDatabase().use { database ->
+            database.delete("gpkg_extensions", "table_name=?", arrayOf(extension.tableName))
+        }
+    }
+
+    override suspend fun deleteGriddedCoverage(griddedCoverage: GpkgGriddedCoverage) {
+        connection.openDatabase().use { database ->
+            val args = arrayOf(griddedCoverage.tileMatrixSetName)
+            database.delete("gpkg_2d_gridded_coverage_ancillary", "tile_matrix_set_name=?", args)
+        }
+    }
+
+    override suspend fun deleteGriddedTiles(tableName: String) {
+        connection.openDatabase().use { database ->
+            database.delete("gpkg_2d_gridded_tile_ancillary", "tpudt_name=?", arrayOf(tableName))
+        }
+    }
+
+    override suspend fun dropTilesTable(tableName: String) {
+        connection.openDatabase().use { database -> database.execSQL("DROP TABLE $tableName") }
+    }
 }

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/globe/terrain/BasicTessellator.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/globe/terrain/BasicTessellator.kt
@@ -91,7 +91,8 @@ open class BasicTessellator: Tessellator, TileFactory {
         val pool = rc.getDrawablePool<BasicDrawableTerrain>()
         val drawable = BasicDrawableTerrain.obtain(pool)
         prepareDrawableTerrain(rc, tile, drawable)
-        rc.offerDrawableTerrain(drawable, tile.distanceToCamera)
+        val sortOrder = tile.drawSortOrder(rc)
+        rc.offerDrawableTerrain(drawable, sortOrder)
     }
 
     protected open fun invalidateTiles() {

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/render/RenderContext.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/render/RenderContext.kt
@@ -341,8 +341,8 @@ open class RenderContext {
         drawableQueue?.offerDrawable(drawable, DrawableGroup.SHAPE, -cameraDistance) // order by descending distance to the viewer
     }
 
-    fun offerDrawableTerrain(drawable: DrawableTerrain, cameraDistance: Double) {
-        drawableTerrain?.offerDrawable(drawable, DrawableGroup.SURFACE, cameraDistance) // order by increasing distance to the viewer
+    fun offerDrawableTerrain(drawable: DrawableTerrain, sortOrder: Double) {
+        drawableTerrain?.offerDrawable(drawable, DrawableGroup.SURFACE, sortOrder)
     }
 
     fun sortDrawables() {

--- a/worldwind/src/jvmCommonMain/kotlin/earth/worldwind/layer/AbstractTiledImageLayer.kt
+++ b/worldwind/src/jvmCommonMain/kotlin/earth/worldwind/layer/AbstractTiledImageLayer.kt
@@ -30,10 +30,20 @@ actual abstract class AbstractTiledImageLayer actual constructor(name: String): 
         get() = tiledSurfaceImage?.useCacheOnly ?: false
         set(value) { tiledSurfaceImage?.useCacheOnly = value }
 
+    protected var cacheContent: GpkgContent? = null
+
     /**
      * Removes cache provider from current tiled image layer.
      */
-    fun disableCache() { tiledSurfaceImage?.cacheTileFactory = null }
+    fun disableCache() {
+        cacheContent = null
+        tiledSurfaceImage?.cacheTileFactory = null
+    }
+
+    /**
+     * Delete all tiles from current cache storage
+     */
+    suspend fun clearCache() = cacheContent?.run { container.deleteContent(tableName) }.also { disableCache() }
 
     protected open suspend fun getOrSetupTilesContent(pathName: String, tableName: String, readOnly: Boolean, isWebp: Boolean): GpkgContent {
         val tiledSurfaceImage = tiledSurfaceImage ?: error("Surface image not defined")

--- a/worldwind/src/jvmMain/kotlin/earth/worldwind/ogc/gpkg/GeoPackage.kt
+++ b/worldwind/src/jvmMain/kotlin/earth/worldwind/ogc/gpkg/GeoPackage.kt
@@ -80,4 +80,32 @@ actual open class GeoPackage actual constructor(pathName: String, isReadOnly: Bo
     override suspend fun readTileUserData(tableName: String, zoom: Int, column: Int, row: Int): GpkgTileUserData? {
         TODO("Not yet implemented")
     }
+
+    override suspend fun deleteContent(content: GpkgContent) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteMatrixSet(matrixSet: GpkgTileMatrixSet) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteMatrix(matrix: GpkgTileMatrix) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteExtension(extension: GpkgExtension) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteGriddedCoverage(griddedCoverage: GpkgGriddedCoverage) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteGriddedTiles(tableName: String) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun dropTilesTable(tableName: String) {
+        TODO("Not yet implemented")
+    }
 }


### PR DESCRIPTION
Ensure exact front to back sorting order for terrain tiles

This approach ensures correct rendering of transparent surface textures. Also its more efficient in terms of fragment shader evaluation. Can be further improved by sorting triangle in index buffer. With Open GLES 3.2 should be possible to use same draw call and single buffer index buffer, just rotatating vertices in fragment shader via use of SSBO or texture buffers - still subject for research.