### PR TITLE
[#33] Fix limitation of 3D path length

### DIFF
--- a/worldwind/src/androidMain/kotlin/earth/worldwind/util/kgl/AndroidKgl.kt
+++ b/worldwind/src/androidMain/kotlin/earth/worldwind/util/kgl/AndroidKgl.kt
@@ -3,6 +3,7 @@ package earth.worldwind.util.kgl
 import android.opengl.GLES20
 import java.nio.ByteBuffer
 import java.nio.FloatBuffer
+import java.nio.IntBuffer
 import java.nio.ShortBuffer
 
 class AndroidKgl : Kgl {
@@ -80,7 +81,8 @@ class AndroidKgl : Kgl {
 
     override fun bufferData(target: Int, size: Int, sourceData: ShortArray, usage: Int, offset: Int) =
         GLES20.glBufferData(target, size, ShortBuffer.wrap(sourceData, offset, size / 2), usage)
-
+    override fun bufferData(target: Int, size: Int, sourceData: IntArray, usage: Int, offset: Int) =
+        GLES20.glBufferData(target, size, IntBuffer.wrap(sourceData, offset, size / 4), usage)
     override fun bufferData(target: Int, size: Int, sourceData: FloatArray, usage: Int, offset: Int) =
         GLES20.glBufferData(target, size, FloatBuffer.wrap(sourceData, offset, size / 4), usage)
 

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/draw/DrawShapeState.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/draw/DrawShapeState.kt
@@ -4,8 +4,8 @@ import earth.worldwind.geom.Matrix3
 import earth.worldwind.geom.Vec3
 import earth.worldwind.render.Color
 import earth.worldwind.render.Texture
+import earth.worldwind.render.buffer.AbstractBufferObject
 import earth.worldwind.render.buffer.FloatBufferObject
-import earth.worldwind.render.buffer.ShortBufferObject
 import earth.worldwind.render.program.BasicShaderProgram
 
 open class DrawShapeState internal constructor() {
@@ -15,7 +15,7 @@ open class DrawShapeState internal constructor() {
 
     var program: BasicShaderProgram? = null
     var vertexBuffer: FloatBufferObject? = null
-    var elementBuffer: ShortBufferObject? = null
+    var elementBuffer: AbstractBufferObject? = null
     val vertexOrigin = Vec3()
     var vertexStride = 0
     var enableCullFace = true

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/FloatBufferObject.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/FloatBufferObject.kt
@@ -3,7 +3,8 @@ package earth.worldwind.render.buffer
 import earth.worldwind.draw.DrawContext
 import earth.worldwind.util.kgl.GL_STATIC_DRAW
 
-open class FloatBufferObject(target: Int, array: FloatArray, size: Int = array.size) : AbstractBufferObject(target, size * 4) {
+open class FloatBufferObject(target: Int, array: FloatArray, size: Int = array.size)
+    : AbstractBufferObject(target, size * Float.SIZE_BYTES) {
     protected var array: FloatArray? = array
 
     override fun release(dc: DrawContext) {

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/IntBufferObject.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/IntBufferObject.kt
@@ -3,7 +3,8 @@ package earth.worldwind.render.buffer
 import earth.worldwind.draw.DrawContext
 import earth.worldwind.util.kgl.GL_STATIC_DRAW
 
-open class IntBufferObject(target: Int, array: IntArray, size: Int = array.size) : AbstractBufferObject(target, size * 4) {
+open class IntBufferObject(target: Int, array: IntArray, size: Int = array.size)
+    : AbstractBufferObject(target, size * Int.SIZE_BYTES) {
     protected var array: IntArray? = array
 
     override fun release(dc: DrawContext) {

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/IntBufferObject.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/IntBufferObject.kt
@@ -1,0 +1,22 @@
+package earth.worldwind.render.buffer
+
+import earth.worldwind.draw.DrawContext
+import earth.worldwind.util.kgl.GL_STATIC_DRAW
+
+open class IntBufferObject(target: Int, array: IntArray, size: Int = array.size) : AbstractBufferObject(target, size * 4) {
+    protected var array: IntArray? = array
+
+    override fun release(dc: DrawContext) {
+        super.release(dc)
+        array = null // array can be non-null if the object has not been bound
+    }
+
+    override fun bindBuffer(dc: DrawContext): Boolean {
+        array?.let{ loadBuffer(dc) }.also { array = null }
+        return super.bindBuffer(dc)
+    }
+
+    override fun loadBufferObjectData(dc: DrawContext) {
+        array?.let { dc.gl.bufferData(target, byteCount, it, GL_STATIC_DRAW) }
+    }
+}

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/ShortBufferObject.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/ShortBufferObject.kt
@@ -3,7 +3,8 @@ package earth.worldwind.render.buffer
 import earth.worldwind.draw.DrawContext
 import earth.worldwind.util.kgl.GL_STATIC_DRAW
 
-open class ShortBufferObject(target: Int, array: ShortArray, size: Int = array.size) : AbstractBufferObject(target, size * 2) {
+open class ShortBufferObject(target: Int, array: ShortArray, size: Int = array.size)
+    : AbstractBufferObject(target, size * Short.SIZE_BYTES) {
     protected var array: ShortArray? = array
 
     override fun release(dc: DrawContext) {

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/util/kgl/Kgl.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/util/kgl/Kgl.kt
@@ -412,6 +412,7 @@ interface Kgl {
     fun createBuffer(): KglBuffer
     fun bindBuffer(target: Int, buffer: KglBuffer)
     fun bufferData(target: Int, size: Int, sourceData: ShortArray, usage: Int, offset: Int = 0)
+    fun bufferData(target: Int, size: Int, sourceData: IntArray, usage: Int, offset: Int = 0)
     fun bufferData(target: Int, size: Int, sourceData: FloatArray, usage: Int, offset: Int = 0)
     fun deleteBuffer(buffer: KglBuffer)
 

--- a/worldwind/src/jsMain/kotlin/earth/worldwind/util/kgl/WebKgl.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/util/kgl/WebKgl.kt
@@ -92,6 +92,12 @@ class WebKgl(val gl: WebGLRenderingContext) : Kgl {
         gl.bufferData(target, if (offset == 0 && len == arr.length) arr else arr.subarray(offset, offset + len), usage)
     }
 
+    override fun bufferData(target: Int, size: Int, sourceData: IntArray, usage: Int, offset: Int) {
+        val arr = sourceData.unsafeCast<Int32Array>()
+        val len = size / 4
+        gl.bufferData(target, if (offset == 0 && len == arr.length) arr else arr.subarray(offset, offset + len), usage)
+    }
+
     override fun bufferData(target: Int, size: Int, sourceData: FloatArray, usage: Int, offset: Int) {
         val arr = sourceData.unsafeCast<Float32Array>()
         val len = size / 4

--- a/worldwind/src/jvmMain/kotlin/earth/worldwind/util/kgl/JoglKgl.kt
+++ b/worldwind/src/jvmMain/kotlin/earth/worldwind/util/kgl/JoglKgl.kt
@@ -93,6 +93,9 @@ class JoglKgl(private val gl: GL3ES3) : Kgl {
     override fun bufferData(target: Int, size: Int, sourceData: ShortArray, usage: Int, offset: Int) =
         gl.glBufferData(target, size.toLong(), ShortBuffer.wrap(sourceData, offset, sourceData.size - offset), usage)
 
+    override fun bufferData(target: Int, size: Int, sourceData: IntArray, usage: Int, offset: Int) =
+        gl.glBufferData(target, size.toLong(), IntBuffer.wrap(sourceData, offset, sourceData.size - offset), usage)
+
     override fun bufferData(target: Int, size: Int, sourceData: FloatArray, usage: Int, offset: Int) =
         gl.glBufferData(target, size.toLong(), FloatBuffer.wrap(sourceData, offset, sourceData.size - offset), usage)
 

--- a/worldwind/src/jvmMain/kotlin/earth/worldwind/util/kgl/LwjglKgl.kt
+++ b/worldwind/src/jvmMain/kotlin/earth/worldwind/util/kgl/LwjglKgl.kt
@@ -3,6 +3,7 @@ package earth.worldwind.util.kgl
 import org.lwjgl.opengl.GL33
 import java.nio.ByteBuffer
 import java.nio.FloatBuffer
+import java.nio.IntBuffer
 import java.nio.ShortBuffer
 
 class LwjglKgl : Kgl {
@@ -75,6 +76,9 @@ class LwjglKgl : Kgl {
 
     override fun bufferData(target: Int, size: Int, sourceData: ShortArray, usage: Int, offset: Int) =
         GL33.glBufferData(target, ShortBuffer.wrap(sourceData, offset, sourceData.size - offset), usage)
+
+    override fun bufferData(target: Int, size: Int, sourceData: IntArray, usage: Int, offset: Int) =
+        GL33.glBufferData(target, IntBuffer.wrap(sourceData, offset, sourceData.size - offset), usage)
 
     override fun bufferData(target: Int, size: Int, sourceData: FloatArray, usage: Int, offset: Int) =
         GL33.glBufferData(target, FloatBuffer.wrap(sourceData, offset, sourceData.size - offset), usage)


### PR DESCRIPTION
The main reason the Path has limited number of points to be drawn is that vertexBuffer indices are UNSIGNED_SHORT type and thus unique index values are limited due to "Max Short" value.

Add IntBufferObject, make Path use it as drawState.elementBuffer. Change interiorElements, outlineElements and verticalElements type to Int.

	modified:   worldwind/src/androidMain/kotlin/earth/worldwind/util/kgl/AndroidKgl.kt
	modified:   worldwind/src/commonMain/kotlin/earth/worldwind/draw/DrawShapeState.kt
	new file:   worldwind/src/commonMain/kotlin/earth/worldwind/render/buffer/IntBufferObject.kt
	modified:   worldwind/src/commonMain/kotlin/earth/worldwind/shape/Path.kt
	modified:   worldwind/src/commonMain/kotlin/earth/worldwind/util/kgl/Kgl.kt