### PR TITLE
WorldWindow Web compatible with popup windows.

### DIFF
--- a/worldwind/src/jsMain/kotlin/earth/worldwind/WorldWindow.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/WorldWindow.kt
@@ -13,7 +13,6 @@ import earth.worldwind.util.Logger.logMessage
 import earth.worldwind.util.kgl.WebKgl
 import earth.worldwind.util.window.PrepareEventHandler
 import earth.worldwind.util.window.createDefaultPrepareEventHandler
-import kotlinx.browser.window
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import org.khronos.webgl.WebGLContextAttributes

--- a/worldwind/src/jsMain/kotlin/earth/worldwind/WorldWindow.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/WorldWindow.kt
@@ -161,8 +161,8 @@ open class WorldWindow(
     fun addEventListener(type: String, listener: EventListener) {
         var entry = eventListeners[type]
         if (entry == null) {
-            entry = EventListenerEntry {
-                dirtyEvent -> val event = prepareEvent(dirtyEvent)
+            entry = EventListenerEntry { dirtyEvent ->
+                val event = prepareEvent(dirtyEvent)
                 event.asDynamic().worldWindow = this@WorldWindow
                 // calls listeners in reverse registration order
                 entry?.listeners?.forEach{ l -> l.handleEvent(event) }

--- a/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/PrepareEventHandler.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/PrepareEventHandler.kt
@@ -1,0 +1,5 @@
+package earth.worldwind.util.window
+
+import org.w3c.dom.events.Event
+
+typealias PrepareEventHandler = (event: Event) -> Event

--- a/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/createDefaultPrepareEventHandler.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/createDefaultPrepareEventHandler.kt
@@ -1,0 +1,8 @@
+package earth.worldwind.util.window
+
+import org.w3c.dom.HTMLCanvasElement
+
+fun createDefaultPrepareEventHandler(canvas: HTMLCanvasElement): PrepareEventHandler {
+    // This check will false for technically valid canvas from children window
+    return if (canvas is HTMLCanvasElement) prepareEventVoid  else prepareEventDefault
+}

--- a/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/createDefaultPrepareEventHandler.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/createDefaultPrepareEventHandler.kt
@@ -3,6 +3,6 @@ package earth.worldwind.util.window
 import org.w3c.dom.HTMLCanvasElement
 
 fun createDefaultPrepareEventHandler(canvas: HTMLCanvasElement): PrepareEventHandler {
-    // This check will false for technically valid canvas from children window
+    // This check will false for technically valid canvas from child windows
     return if (canvas is HTMLCanvasElement) prepareEventVoid  else prepareEventDefault
 }

--- a/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/prepareEventDefault.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/prepareEventDefault.kt
@@ -1,0 +1,130 @@
+package earth.worldwind.util.window
+
+import org.w3c.dom.TouchEvent
+import org.w3c.dom.events.MouseEvent
+import org.w3c.dom.events.MouseEventInit
+import org.w3c.dom.events.WheelEvent
+import org.w3c.dom.events.WheelEventInit
+import org.w3c.dom.pointerevents.PointerEvent
+import org.w3c.dom.pointerevents.PointerEventInit
+
+/**
+ * If we use multi window features of a browser,
+ * we need to create window.*Event instances, to work
+ * with them in the code of the main window (where the application is running).
+ *
+ * This function isn't part of the class itself and may be altered
+ * with another implementations, because the way of cloning may be imprecise
+ * for purposes of particular application.
+ */
+val prepareEventDefault: PrepareEventHandler = { event ->
+    when (true) {
+        event.type.startsWith("mouse") -> {
+            val e0 = event.unsafeCast<MouseEvent>()
+            MouseEvent(
+                e0.type, MouseEventInit(
+                    bubbles = e0.bubbles,
+                    cancelable = e0.cancelable,
+                    clientX = e0.clientX,
+                    clientY = e0.clientY,
+                    screenX = e0.screenX,
+                    screenY = e0.screenY,
+                    button = e0.button,
+                    buttons = e0.buttons,
+                    relatedTarget = e0.relatedTarget
+                )
+            )
+        }
+
+        event.type.startsWith("pointer") -> {
+            val e0 = event.unsafeCast<PointerEvent>()
+            PointerEvent(
+                e0.type, PointerEventInit(
+                    bubbles = e0.bubbles,
+                    cancelable = e0.cancelable,
+                    composed = e0.composed,
+
+                    clientX = e0.clientX,
+                    clientY = e0.clientY,
+                    screenX = e0.screenX,
+                    screenY = e0.screenY,
+
+                    button = e0.button,
+                    buttons = e0.buttons,
+                    relatedTarget = e0.relatedTarget,
+
+                    pointerId = e0.pointerId,
+                    width = e0.width,
+                    height = e0.height,
+                    pressure = e0.pressure,
+                    tangentialPressure = e0.tangentialPressure,
+                    tiltX = e0.tiltX,
+                    tiltY = e0.tiltY,
+                    twist = e0.twist,
+
+                    pointerType = e0.pointerType,
+                    isPrimary = e0.isPrimary
+                )
+            )
+        }
+
+        (event.type == "wheel") -> {
+            val e0 = event.unsafeCast<WheelEvent>()
+            WheelEvent(
+                e0.type, WheelEventInit(
+                    bubbles = e0.bubbles,
+                    cancelable = e0.cancelable,
+                    composed = e0.composed,
+                    deltaX = e0.deltaX,
+                    deltaY = e0.deltaY,
+                    deltaZ = e0.deltaZ,
+                    deltaMode = e0.deltaMode,
+                    clientX = e0.clientX,
+                    clientY = e0.clientY,
+                    screenX = e0.screenX,
+                    screenY = e0.screenY,
+                    ctrlKey = e0.ctrlKey,
+                    shiftKey = e0.shiftKey,
+                    altKey = e0.altKey,
+                    metaKey = e0.metaKey,
+                    button = e0.button,
+                    buttons = e0.buttons,
+                    relatedTarget = e0.relatedTarget
+                )
+            )
+        }
+
+        /**
+         * It may work not in all browsers correctly.
+         */
+        event.type.startsWith("touch") -> try {
+            val e0 = event.unsafeCast<TouchEvent>()
+            // Create new event this way, because `TouchEvent` constructor doesn't accept event type.
+            val clone = js(
+                "new TouchEvent(e0.type, {" +
+                        "bubbles: e0.bubbles," +
+                        "cancelable: e0.cancelable," +
+                        "composed: e0.composed," +
+                        "touches: e0.touches," +
+                        "targetTouches: e0.targetTouches," +
+                        "changedTouches: e0.changedTouches," +
+                        "ctrlKey: e0.ctrlKey," +
+                        "shiftKey: e0.shiftKey," +
+                        "altKey: e0.altKey," +
+                        "metaKey: e0.metaKey," +
+                        "detail: e0.detail," +
+                        "which: e0.which," +
+                        "})"
+            ) as TouchEvent
+            clone
+        } catch (e: Throwable) {
+            console.warn("Failed to adapt touch event: ${event.type}. May window will fail even type checks.", e)
+            event
+        }
+
+        else -> {
+            console.info("Event converter between windows is not implemented for event type: ${event.type}.")
+            event
+        }
+    }
+}

--- a/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/prepareEventDefault.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/prepareEventDefault.kt
@@ -17,79 +17,79 @@ import org.w3c.dom.pointerevents.PointerEventInit
  * with another implementations, because the way of cloning may be imprecise
  * for purposes of particular application.
  */
-val prepareEventDefault: PrepareEventHandler = { event ->
+val prepareEventDefault: PrepareEventHandler = { dirtyEvent ->
     when (true) {
-        event.type.startsWith("mouse") -> {
-            val e0 = event.unsafeCast<MouseEvent>()
+        dirtyEvent.type.startsWith("mouse") -> {
+            val event = dirtyEvent.unsafeCast<MouseEvent>()
             MouseEvent(
-                e0.type, MouseEventInit(
-                    bubbles = e0.bubbles,
-                    cancelable = e0.cancelable,
-                    clientX = e0.clientX,
-                    clientY = e0.clientY,
-                    screenX = e0.screenX,
-                    screenY = e0.screenY,
-                    button = e0.button,
-                    buttons = e0.buttons,
-                    relatedTarget = e0.relatedTarget
+                event.type, MouseEventInit(
+                    bubbles = event.bubbles,
+                    cancelable = event.cancelable,
+                    clientX = event.clientX,
+                    clientY = event.clientY,
+                    screenX = event.screenX,
+                    screenY = event.screenY,
+                    button = event.button,
+                    buttons = event.buttons,
+                    relatedTarget = event.relatedTarget
                 )
             )
         }
 
-        event.type.startsWith("pointer") -> {
-            val e0 = event.unsafeCast<PointerEvent>()
+        dirtyEvent.type.startsWith("pointer") -> {
+            val event = dirtyEvent.unsafeCast<PointerEvent>()
             PointerEvent(
-                e0.type, PointerEventInit(
-                    bubbles = e0.bubbles,
-                    cancelable = e0.cancelable,
-                    composed = e0.composed,
+                event.type, PointerEventInit(
+                    bubbles = event.bubbles,
+                    cancelable = event.cancelable,
+                    composed = event.composed,
 
-                    clientX = e0.clientX,
-                    clientY = e0.clientY,
-                    screenX = e0.screenX,
-                    screenY = e0.screenY,
+                    clientX = event.clientX,
+                    clientY = event.clientY,
+                    screenX = event.screenX,
+                    screenY = event.screenY,
 
-                    button = e0.button,
-                    buttons = e0.buttons,
-                    relatedTarget = e0.relatedTarget,
+                    button = event.button,
+                    buttons = event.buttons,
+                    relatedTarget = event.relatedTarget,
 
-                    pointerId = e0.pointerId,
-                    width = e0.width,
-                    height = e0.height,
-                    pressure = e0.pressure,
-                    tangentialPressure = e0.tangentialPressure,
-                    tiltX = e0.tiltX,
-                    tiltY = e0.tiltY,
-                    twist = e0.twist,
+                    pointerId = event.pointerId,
+                    width = event.width,
+                    height = event.height,
+                    pressure = event.pressure,
+                    tangentialPressure = event.tangentialPressure,
+                    tiltX = event.tiltX,
+                    tiltY = event.tiltY,
+                    twist = event.twist,
 
-                    pointerType = e0.pointerType,
-                    isPrimary = e0.isPrimary
+                    pointerType = event.pointerType,
+                    isPrimary = event.isPrimary
                 )
             )
         }
 
-        (event.type == "wheel") -> {
-            val e0 = event.unsafeCast<WheelEvent>()
+        (dirtyEvent.type == "wheel") -> {
+            val event = dirtyEvent.unsafeCast<WheelEvent>()
             WheelEvent(
-                e0.type, WheelEventInit(
-                    bubbles = e0.bubbles,
-                    cancelable = e0.cancelable,
-                    composed = e0.composed,
-                    deltaX = e0.deltaX,
-                    deltaY = e0.deltaY,
-                    deltaZ = e0.deltaZ,
-                    deltaMode = e0.deltaMode,
-                    clientX = e0.clientX,
-                    clientY = e0.clientY,
-                    screenX = e0.screenX,
-                    screenY = e0.screenY,
-                    ctrlKey = e0.ctrlKey,
-                    shiftKey = e0.shiftKey,
-                    altKey = e0.altKey,
-                    metaKey = e0.metaKey,
-                    button = e0.button,
-                    buttons = e0.buttons,
-                    relatedTarget = e0.relatedTarget
+                event.type, WheelEventInit(
+                    bubbles = event.bubbles,
+                    cancelable = event.cancelable,
+                    composed = event.composed,
+                    deltaX = event.deltaX,
+                    deltaY = event.deltaY,
+                    deltaZ = event.deltaZ,
+                    deltaMode = event.deltaMode,
+                    clientX = event.clientX,
+                    clientY = event.clientY,
+                    screenX = event.screenX,
+                    screenY = event.screenY,
+                    ctrlKey = event.ctrlKey,
+                    shiftKey = event.shiftKey,
+                    altKey = event.altKey,
+                    metaKey = event.metaKey,
+                    button = event.button,
+                    buttons = event.buttons,
+                    relatedTarget = event.relatedTarget
                 )
             )
         }
@@ -97,34 +97,34 @@ val prepareEventDefault: PrepareEventHandler = { event ->
         /**
          * It may work not in all browsers correctly.
          */
-        event.type.startsWith("touch") -> try {
-            val e0 = event.unsafeCast<TouchEvent>()
+        dirtyEvent.type.startsWith("touch") -> try {
+            val event = dirtyEvent.unsafeCast<TouchEvent>()
             // Create new event this way, because `TouchEvent` constructor doesn't accept event type.
             val clone = js(
-                "new TouchEvent(e0.type, {" +
-                        "bubbles: e0.bubbles," +
-                        "cancelable: e0.cancelable," +
-                        "composed: e0.composed," +
-                        "touches: e0.touches," +
-                        "targetTouches: e0.targetTouches," +
-                        "changedTouches: e0.changedTouches," +
-                        "ctrlKey: e0.ctrlKey," +
-                        "shiftKey: e0.shiftKey," +
-                        "altKey: e0.altKey," +
-                        "metaKey: e0.metaKey," +
-                        "detail: e0.detail," +
-                        "which: e0.which," +
+                "new TouchEvent(event.type, {" +
+                        "bubbles: event.bubbles," +
+                        "cancelable: event.cancelable," +
+                        "composed: event.composed," +
+                        "touches: event.touches," +
+                        "targetTouches: event.targetTouches," +
+                        "changedTouches: event.changedTouches," +
+                        "ctrlKey: event.ctrlKey," +
+                        "shiftKey: event.shiftKey," +
+                        "altKey: event.altKey," +
+                        "metaKey: event.metaKey," +
+                        "detail: event.detail," +
+                        "which: event.which," +
                         "})"
             ) as TouchEvent
             clone
         } catch (e: Throwable) {
-            console.warn("Failed to adapt touch event: ${event.type}. May window will fail even type checks.", e)
-            event
+            console.warn("Failed to adapt touch event: ${dirtyEvent.type}. May window will fail even type checks.", e)
+            dirtyEvent
         }
 
         else -> {
-            console.info("Event converter between windows is not implemented for event type: ${event.type}.")
-            event
+            console.info("Event converter between windows is not implemented for event type: ${dirtyEvent.type}.")
+            dirtyEvent
         }
     }
 }

--- a/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/prepareEventVoid.kt
+++ b/worldwind/src/jsMain/kotlin/earth/worldwind/util/window/prepareEventVoid.kt
@@ -1,0 +1,7 @@
+package earth.worldwind.util.window
+
+/**
+ * If we don't use multi window features of a browser,
+ * we are safe to just pass the event further.
+ */
+val prepareEventVoid: PrepareEventHandler = { event -> event }


### PR DESCRIPTION
When one tries to create a popup window and draw there a canvas with the worldwind he or she will experience issues with class casting.

The reason is well explained here: https://dev.to/noriste/the-challenges-of-rendering-an-openlayers-map-in-a-popup-through-react-2elh

### The short description of the problem
When child window produces an event the code in main window can't perform actions like instanceof (is - in Kotlin) correctly. Because Kotlin tries to adapt javascript classes just from window object - instance-checking won't work.
Also current window for the canvas is not window, but canvas.ownerDocument.defaultView, so event listeners manipulations should be called from this child window as a correct context.

### The solution
1. Use ownerDocument.defaultView from canvas instead of global window
2. Unsafe type-casting to avoid type cast error problem
3. Cloning event objets from ownerDocument.defaultView.*Event classes to window.*Event classes to make isntanceof(is) checking work on their classes, to pass them to the logic that expect window.*Event based objects to work.
4. Replace "is"-checking with runtime class name comparison.

### General peculiarities of the solution
```prepareEventDefault``` - function is a reference implementation of event cloner. Some projects or browsers except chome may require different implementations. So we made prepareEvent helper a variable util.
1. Because Kotlin/Js doesn't provide some nice methods to extract properties in iterations from js objects of arbitrary structure, we manually clone events, copying necessary properties depending on the type.
2. Because in the future something can change, or necessity of other properties may arise, or new bugs are found we made event cloner passible as a dependency to WorldWindow constructor. It will allow to fix issues with events on the go without a need to get new fixed version of worldwind object.

### Miscellaneous
Tested with: 
- Chrome 
- Safari 