### PR TITLE
Feature improved atmosphere layer

### DIFF
--- a/worldwind/src/commonMain/kotlin/earth/worldwind/layer/atmosphere/AbstractAtmosphereProgram.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/layer/atmosphere/AbstractAtmosphereProgram.kt
@@ -54,9 +54,9 @@ abstract class AbstractAtmosphereProgram: AbstractShaderProgram() {
             1 / 0.570.pow(4.0),  // 570 nm for green
             1 / 0.475.pow(4.0)   // 475 nm for blue
         )
-        val kr = 0.0025 // Rayleigh scattering constant
-        val km = 0.0010 // Mie scattering constant
-        val eSun = 20.0 // Sun brightness constant
+        val kr = 0.0030 // Rayleigh scattering constant (increased for richer blue sky)
+        val km = 0.0008 // Mie scattering constant (reduced to limit white haze)
+        val eSun = 22.0 // Sun brightness constant
         val g = -0.990 // The Mie phase asymmetry factor
         val exposure = 2.0
         fragModeId = gl.getUniformLocation(program, "fragMode")

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/layer/atmosphere/GroundProgram.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/layer/atmosphere/GroundProgram.kt
@@ -74,7 +74,13 @@ class GroundProgram: AbstractAtmosphereProgram() {
                 float depth = exp((globeRadius - atmosphereRadius) / scaleDepth);
                 float eyeAngle = dot(-ray, point) / length(point);
                 float lightAngle = dot(lightDirection, point) / length(point);
-                float eyeScale = scaleFunc(eyeAngle);
+                
+                /* Cap eyeScale to limit excessive atmospheric thickness for near-horizontal rays.
+                   (when the camera is close to the ground and look at the horizon)
+                   Only eyeScale is capped: lightScale is untouched so the day/night terminator
+                   and night-side darkening remain physically correct. */
+                float eyeScale = min(scaleFunc(max(eyeAngle, 0.0)), 2.0 * scaleDepth);
+                
                 float lightScale = scaleFunc(lightAngle);
                 float eyeOffset = depth*eyeScale;
                 float temp = (lightScale + eyeScale);
@@ -92,7 +98,11 @@ class GroundProgram: AbstractAtmosphereProgram() {
                 {
                     float height = length(samplePoint);
                     float depth = exp(scaleOverScaleDepth * (globeRadius - height));
-                    float scatter = depth*temp - eyeOffset;
+                    
+                    // Clamp scatter to 0 to prevent negative values (non-physical brightening) which cause absurd values (negative lightning)
+                    // No upper clamp: the night side needs large scatter values to go fully dark.
+                    float scatter = max(0.0, depth*temp - eyeOffset);
+                    
                     attenuate = exp(-scatter * (invWavelength * Kr4PI + Km4PI));
                     frontColor += attenuate * (depth * scaledLength);
                     samplePoint += sampleRay;

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/layer/atmosphere/SkyProgram.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/layer/atmosphere/SkyProgram.kt
@@ -112,6 +112,7 @@ class SkyProgram : AbstractAtmosphereProgram() {
             uniform vec3 lightDirection;        /* The direction vector to the light source */
             uniform float g;
             uniform float g2;
+            uniform float exposure;
 
             varying vec3 primaryColor;
             varying vec3 secondaryColor;
@@ -120,8 +121,12 @@ class SkyProgram : AbstractAtmosphereProgram() {
             void main () {
                 float cos = dot(lightDirection, direction) / length(direction);
                 float miePhase = 1.5 * ((1.0 - g2) / (2.0 + g2)) * (1.0 + cos*cos) / pow(1.0 + g2 - 2.0*g*cos, 1.5);
-                vec3 color = primaryColor + secondaryColor * miePhase;
-                gl_FragColor = vec4(color * color.b, color.b);
+                vec3 hdrColor = primaryColor + secondaryColor * miePhase;
+                /* Exposure-based HDR tone mapping: physically correct, preserves blue hue.
+                   Replaces the previous "color * color.b" which incorrectly darkened the sky
+                   when the blue channel was low (e.g. looking away from the sun). */
+                vec3 color = 1.0 - exp(-exposure * hdrColor);
+                gl_FragColor = vec4(color, color.b);
             }
         """.trimIndent()
     )

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/layer/starfield/StarFieldProgram.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/layer/starfield/StarFieldProgram.kt
@@ -56,6 +56,7 @@ class StarFieldProgram : AbstractShaderProgram() {
             }
         """.trimIndent(),
         """
+            #version 120
             #ifdef GL_ES
             precision mediump float;
             #endif

--- a/worldwind/src/commonMain/kotlin/earth/worldwind/layer/starfield/StarFieldProgram.kt
+++ b/worldwind/src/commonMain/kotlin/earth/worldwind/layer/starfield/StarFieldProgram.kt
@@ -56,7 +56,6 @@ class StarFieldProgram : AbstractShaderProgram() {
             }
         """.trimIndent(),
         """
-            #version 120
             #ifdef GL_ES
             precision mediump float;
             #endif


### PR DESCRIPTION
Fixed buggy values for atmosphere which cause negative lighting when the viewer is close to the ground and look at the horizon
The bug:
<img width="1718" height="1370" alt="Screenshot_2026-04-18_14-54-20" src="https://github.com/user-attachments/assets/7afbcc6e-4f0e-4702-8b05-3ea54e9acfaf" />
<img width="1717" height="1365" alt="Screenshot_2026-04-18_14-48-48" src="https://github.com/user-attachments/assets/643a9d29-6049-4e08-8a0b-e86ce71c8a4c" />
With the fix:
<img width="1760" height="1448" alt="Capture d’écran du 2026-04-19 00-07-58" src="https://github.com/user-attachments/assets/7846e33c-de75-47ec-8702-50fd41a8db7d" />